### PR TITLE
Better handling of periods in filename

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -9,11 +9,17 @@ function home(response, postData) {
 function upload(response, postData) {
 
   var file = JSON.parse(postData);
-  var fileRootName = file.name.split('.').shift();
-  var fileExtension = file.name.split('.').pop();
+  var segments = [file.name]
+  var fileExtension = '';
+  if (file.name.indexOf('.') != -1)
+  {
+    segments = file.name.split('.');
+    fileExtension = segments.pop();
+  }
+  var fileRootName = segments.join('.');
   var filePathBase = config.upload_dir + '/';
   var fileRootNameWithBase = filePathBase + fileRootName;
-  var filePath = fileRootNameWithBase + '.' + fileExtension;
+  var filePath = filePathBase + file.name;
   var fileID = 2;
   var fileBuffer;
 

--- a/handlers.js
+++ b/handlers.js
@@ -9,9 +9,9 @@ function home(response, postData) {
 function upload(response, postData) {
 
   var file = JSON.parse(postData);
-  var segments = [file.name]
+  var segments = [file.name];
   var fileExtension = '';
-  if (file.name.indexOf('.') != -1)
+  if ( file.name.indexOf('.') != -1 )
   {
     segments = file.name.split('.');
     fileExtension = segments.pop();
@@ -24,7 +24,7 @@ function upload(response, postData) {
   var fileBuffer;
 
   while ( fs.existsSync(filePath) ) {
-    if (fileExtension != '')
+    if ( fileExtension != '' )
       filePath = fileRootNameWithBase + '(' + fileID + ').' + fileExtension;
     else
       filePath = fileRootNameWithBase + '(' + fileID + ')';

--- a/handlers.js
+++ b/handlers.js
@@ -24,7 +24,10 @@ function upload(response, postData) {
   var fileBuffer;
 
   while ( fs.existsSync(filePath) ) {
-    filePath = fileRootNameWithBase + '(' + fileID + ').' + fileExtension;
+    if (fileExtension != '')
+      filePath = fileRootNameWithBase + '(' + fileID + ').' + fileExtension;
+    else
+      filePath = fileRootNameWithBase + '(' + fileID + ')';
     fileID += 1;
   }
 


### PR DESCRIPTION
The file uploader works as expected with a file that has one period (like x.jpg, the period to designate the file extension).  However, if there was no file extension on the file, or if there were multiple periods in the filename, then the file names would get mangled when the files were saved:

![1](https://cloud.githubusercontent.com/assets/148768/10748932/f29d1c2c-7c32-11e5-9caf-e531e4d31380.png)

This PR helps to resolve these issues:

![2](https://cloud.githubusercontent.com/assets/148768/10748937/f88e3288-7c32-11e5-8da1-51d94de7100f.png)

![3](https://cloud.githubusercontent.com/assets/148768/10748944/06a168c2-7c33-11e5-8cd7-0aa734dd5dab.png)
