### PR TITLE
Add ability to configure host to bind server to 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Simple File Uploader
 
+## Forked to add ability to select host and port to bind to
+
 [![Code Climate](https://codeclimate.com/github/merty/simple-file-uploader/badges/gpa.svg)](https://codeclimate.com/github/merty/simple-file-uploader)
 
 Simple File Uploader is a file uploader written using HTML5 and Node.js. It can upload both to a local directory on the server or to an AWS S3 server.

--- a/config.js
+++ b/config.js
@@ -1,5 +1,6 @@
 module.exports = {
   port: 8000,
+  host: 'localhost',
   s3: {
     key: '',
     secret: '',

--- a/config.js
+++ b/config.js
@@ -1,6 +1,6 @@
 module.exports = {
   port: 8000,
-  host: 'localhost',
+  host: '0.0.0.0',
   s3: {
     key: '',
     secret: '',

--- a/handlers.js
+++ b/handlers.js
@@ -24,7 +24,7 @@ function upload(response, postData) {
 
   file.contents = file.contents.split(',').pop();
 
-  fileBuffer = new Buffer(file.contents, "base64");
+  fileBuffer = Buffer.from(file.contents, "base64");
 
   if ( config.s3_enabled ) {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,75 @@
+{
+  "name": "simple-file-uploader",
+  "version": "0.2.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "debug": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.5.tgz",
+      "integrity": "sha1-9yQSF0MPmd7EwrRz6rkiKOh0wqw=",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "knox": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/knox/-/knox-0.9.2.tgz",
+      "integrity": "sha1-NzZZNmniTwJP2vcjtqHcSv2DmnE=",
+      "requires": {
+        "debug": "1.0.5",
+        "mime": "2.3.1",
+        "once": "1.4.0",
+        "stream-counter": "1.0.0",
+        "xml2js": "0.4.19"
+      }
+    },
+    "mime": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "stream-counter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-1.0.0.tgz",
+      "integrity": "sha1-kc8lac5NxQYf6816yyY5SloRR1E="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "A file uploader written using HTML5 and Node.js. It can upload both to a local directory on the server or to an AWS S3 server.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
+    "start": "node index"
   },
   "repository": {
     "type": "git",
@@ -29,8 +28,5 @@
   "homepage": "https://github.com/merty/simple-file-uploader#readme",
   "dependencies": {
     "knox": "^0.9.2"
-  },
-  "scripts": {
-    "start": "node index"
   }
 }

--- a/server.js
+++ b/server.js
@@ -20,8 +20,8 @@ function start(route, routes) {
     });
   }
 
-  http.createServer(onRequest).listen(config.port);
-  console.log('Started HTTP server on port ' + config.port + '...');
+  http.createServer(onRequest).listen(config.port, config.host);
+  console.log('Started HTTP server on ' + config.host  + ':' + config.port + '...');
 }
 
 module.exports = {

--- a/server.js
+++ b/server.js
@@ -20,7 +20,15 @@ function start(route, routes) {
     });
   }
 
-  http.createServer(onRequest).listen(config.port, config.host);
+  var server = http.createServer(onRequest).listen(config.port, config.host);
+
+  server.on('error', function(e) {
+    if (e.code === 'EADDRINUSE') {
+      console.log('ERROR: Port number already in use. Select a different port number in config.js.');
+      server.close();
+    }
+  })
+
   console.log('Started HTTP server on ' + config.host  + ':' + config.port + '...');
 }
 


### PR DESCRIPTION
This PR makes it possible to bind to 0.0.0.0 in order to easily access this server from the local network.

The default is still to bind to localhost, so default behavior remains the same.

This makes it easier to access the server from a different device on the local network, or a VM.